### PR TITLE
Accept functions as arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,8 @@ gulp.task('rollup', () => {
     .pipe(rollupEach({
       // bundle.generate( options )
       format: 'iife'
-    })
+    }))
     .pipe(gulp.dest('dist'))
-  )
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,27 @@ gulp.task('rollup', () => {
 })
 ```
 
+You can also pass a function that returns rollup options object as an argument. The function will receive [vinyl](https://github.com/gulpjs/vinyl) file object.
+
+```js
+var path = require('path')
+var gulp = require('gulp')
+var rollupEach = require('gulp-rollup-each')
+
+gulp.task('rollup', () => {
+  return gulp.src('src/*.js')
+    .pipe(rollupEach({
+      plugins: [/* ... */]
+    }, (file) => {
+      return {
+        format: 'umd',
+        moduleName: path.basename(file.path, '.js')
+      }
+    }))
+    .pipe(gulp.dest('dist'))
+})
+```
+
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -10,12 +10,14 @@ var gulp = require('gulp')
 var rollupEach = require('gulp-rollup-each')
 
 gulp.task('rollup', () => {
-  gulp.src('src/*.js')
+  return gulp.src('src/*.js')
     .pipe(rollupEach({
       // bundle.generate( options )
       format: 'iife'
     })
     .pipe(gulp.dest('dist'))
+  )
+})
 ```
 
 with sourcemaps and Buble
@@ -27,7 +29,7 @@ var rollupEach = require('gulp-rollup-each')
 var rollupBuble = require('rollup-plugin-buble')
 
 gulp.task('rollup', () => {
-  gulp.src('src/*.js')
+  return gulp.src('src/*.js')
     .pipe(sourcemaps.init())
     .pipe(rollupEach({
       // rollup.rollup( options )
@@ -47,9 +49,10 @@ gulp.task('rollup', () => {
       globals: {
         jquery: 'jQuery'
       }
-    })
+    }))
     .pipe(sourcemaps.write())
     .pipe(gulp.dest('dist'))
+})
 ```
 
 ## License

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,13 +4,18 @@ const rollup = require('rollup').rollup
 const applySourceMap = require('vinyl-sourcemaps-apply')
 
 module.exports = function (arg1, arg2) {
+  arg2 = arg2 || arg1
+
   return new class extends Transform {
     _transform (file, encoding, cb) {
       const entry = path.relative(file.cwd, file.path)
-      const rollupOptions = Object.assign({}, arg1, {
+
+      let rollupOptions = typeof arg1 === 'function' ? arg1(file) : arg1
+      rollupOptions = Object.assign({}, rollupOptions, {
         entry: entry
       })
-      const generateOptions = arg2 || arg1
+
+      const generateOptions = typeof arg2 === 'function' ? arg2(file) : arg2
       const createSourceMap = file.sourceMap !== undefined
 
       generateOptions.sourceMap = createSourceMap


### PR DESCRIPTION
Hello.

I think It would be nice if gulp-rollup-each allows functions as its arguments. This PR introduces the feature.
With this feature, for example, we can configure various `moduleName` based on source file name. :slightly_smiling_face: 