### PR TITLE
Avoid TypeError when calling the function with no arguments

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,7 @@ const rollup = require('rollup').rollup
 const applySourceMap = require('vinyl-sourcemaps-apply')
 
 module.exports = function (arg1, arg2) {
-  arg2 = arg2 || arg1
+  arg2 = arg2 || arg1 || {}
 
   return new class extends Transform {
     _transform (file, encoding, cb) {


### PR DESCRIPTION
Calling ```gulp-rollup-each``` with no arguments, we will get TypeError like the following

```sh
.../node_modules/gulp-rollup-each/lib/index.js:21
generateOptions.sourceMap = createSourceMap
                                ^

TypeError: Cannot set property 'sourceMap' of undefined
```

This PR give default value to arg2.