### PR TITLE
Prevent to catch latter stream errors

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -28,20 +28,22 @@ module.exports = function (arg1, arg2) {
         .then(bundle => {
           return bundle.generate(outputOptions)
         })
-        .then(result => {
-          file.contents = Buffer.from(result.code)
+        .then(
+          result => {
+            file.contents = Buffer.from(result.code)
 
-          if (createSourceMap) {
-            result.map.file = input
-            result.map.sources = result.map.sources.map(source => path.relative(file.cwd, source))
-            applySourceMap(file, result.map)
+            if (createSourceMap) {
+              result.map.file = input
+              result.map.sources = result.map.sources.map(source => path.relative(file.cwd, source))
+              applySourceMap(file, result.map)
+            }
+
+            cb(null, file)
+          },
+          err => {
+            cb(new PluginError(PLUGIN_NAME, err))
           }
-
-          cb(null, file)
-        })
-        .catch(err => {
-          cb(new PluginError(PLUGIN_NAME, err))
-        })
+        )
     }
   }({ objectMode: true })
 }

--- a/test/fixtures/test.js
+++ b/test/fixtures/test.js
@@ -1,0 +1,1 @@
+const test = 'hello';

--- a/test/specs/index.spec.js
+++ b/test/specs/index.spec.js
@@ -1,5 +1,54 @@
-describe('Test', () => {
-  it('should pass', () => {
-    expect(true).toBe(true)
+const path = require('path')
+const fs = require('fs')
+const plugin = require('../../lib')
+const { Readable, Transform } = require('stream')
+
+const fixtureBase = path.resolve(__dirname, '../fixtures')
+
+function mockSrc (fileName) {
+  const cwd = process.cwd()
+  const filePath = path.resolve(fixtureBase, fileName)
+
+  return new Readable({
+    objectMode: true,
+    read () {
+      this.push({
+        cwd,
+        path: filePath,
+        contents: fs.readFileSync(filePath)
+      })
+    }
+  })
+}
+
+function mockTransform (fn) {
+  return new Transform({
+    objectMode: true,
+    transform: fn
+  })
+}
+
+describe('gulp-rollup-each', () => {
+  afterEach(() => {
+    process.removeAllListeners('unhandledRejection')
+  })
+
+  it('should not catch the latter stream error', done => {
+    process.on('unhandledRejection', err => {
+      expect(err.message).toBe('test error')
+      done()
+    })
+
+    mockSrc('test.js')
+      .pipe(plugin({
+        output: { format: 'es' }
+      }))
+      .on('error', err => {
+        // If it reaches here, it accidentally handles the latter stream error.
+        console.error(err)
+      })
+      .pipe(mockTransform(() => {
+        throw new Error('test error')
+      }))
   })
 })


### PR DESCRIPTION
Since the internal `Promise.catch` is placed after the `Promise.then` which has the completion callback, gulp-rollup-each may accidentally catch latter stream errors.

For example, if we have `gulp-uglify` after this plugin:

```js
gulp.task('js', () => {
  return gulp.src(...)
    .pipe(rollupEach(...))
    .pipe(uglify(...))
    .pipe(gulp.dest(...))
})
```

If `uglify` throws an error, `rollupEach` catch it and provides `Error: write callback called multiple times` error.

To prevent this behavior, we can pass the error handler to the 2nd argument of `then` instead of `catch`. So rollup-each plugin does not catch any errors thrown in `then` callback.

I've also added the test case to confirm this behavior.

/ping @ko-yelie 