### PR TITLE
feat: allow to pass rollup object via the 3rd argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ gulp.task('rollup', () => {
 
 ## Options
 
-### `rollupEach(inputOptions [, outputOptions])`
+### `rollupEach(inputOptions [[, outputOptions], rollup])`
 
 #### `inputOptions`
 
@@ -100,6 +100,31 @@ The 2nd argument is the same object as [`outputOptions`](https://rollupjs.org/#o
 If you omit the 2nd argument, `output` in the 1st argument changes to `outputOptions`.
 
 You can also pass a function that returns rollup options object as an argument. The function will receive [vinyl](https://github.com/gulpjs/vinyl) file object.
+
+#### `rollup`
+
+You can specify the 3rd argument for replacing `rollup` object by your dependency. It is useful if you want to use a new version of rollup than gulp-rollup-each is using.
+
+```js
+gulp.task('rollup', () => {
+    return gulp
+    .src(['src/*.js'])
+    .pipe(
+      rollupEach(
+        {},
+        {
+          output: {
+            format: 'iife'
+          }
+        },
+
+        // Passing rollup object
+        require('rollup')
+      )
+    )
+    .pipe(gulp.dest('dist'))
+})
+```
 
 ## License
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,12 +1,14 @@
 const Transform = require('stream').Transform
 const path = require('path')
-const rollup = require('rollup').rollup
+const defaultRollup = require('rollup')
 const applySourceMap = require('vinyl-sourcemaps-apply')
 const PluginError = require('plugin-error')
 
 const PLUGIN_NAME = 'gulp-rollup-each'
 
-module.exports = function (arg1, arg2) {
+module.exports = function (arg1, arg2, injectedRollup) {
+  const rollup = (injectedRollup || defaultRollup).rollup
+
   return new class extends Transform {
     _transform (file, encoding, cb) {
       const input = path.relative(file.cwd, file.path)

--- a/test/specs/index.spec.js
+++ b/test/specs/index.spec.js
@@ -51,4 +51,19 @@ describe('gulp-rollup-each', () => {
         throw new Error('test error')
       }))
   })
+
+  it('can be injected rollup object', done => {
+    const mockRollup = {
+      rollup () {
+        return Promise.reject(new Error('Injected'))
+      }
+    }
+
+    mockSrc('test.js')
+      .pipe(plugin({}, {}, mockRollup))
+      .on('error', err => {
+        expect(err.message).toBe('Injected')
+        done()
+      })
+  })
 })


### PR DESCRIPTION
This patch allows the users to inject rollup object via 3rd argument. It would be useful if they would like to use the latest rollup in their dependencies.