### PR TITLE
Cache Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ gulp.task('rollup', () => {
     .pipe(sourcemaps.init())
     .pipe(rollupEach({
       // inputOptions
-      cache: true, // use rollup cache
+      isCache: true, // use rollup cache
       external: [
         'jquery'
       ],

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ gulp.task('rollup', () => {
     .pipe(sourcemaps.init())
     .pipe(rollupEach({
       // inputOptions
+      cache: true, // use rollup cache
       external: [
         'jquery'
       ],
@@ -100,7 +101,7 @@ gulp.task('rollup', () => {
 #### `inputOptions`
 
 The 1st argument is the same object as [`inputOptions`](https://rollupjs.org/#inputoptions).<br>
-However, the `input` option is the file specified in `gulp.src()`, so it can not be specified as gulp-rollup-each option.
+However, the `input` option is the file specified in `gulp.src()`, so it can not be specified as gulp-rollup-each option. If you use the `cache` option, pass in a `boolean` of `true` instead of an empty variable.
 
 #### `outputOptions`
 

--- a/examples/gulpfile.js
+++ b/examples/gulpfile.js
@@ -5,13 +5,14 @@ const rollupResolve = require('rollup-plugin-node-resolve')
 const rollupCommon = require('rollup-plugin-commonjs')
 const sourcemaps = require('gulp-sourcemaps')
 
-gulp.task('default', () => {
+gulp.task('rollup', () => {
   return gulp.src([
       'src/**/*.js',
       '!src/**/modules/*.js'
     ])
     .pipe(sourcemaps.init())
     .pipe(rollupEach({
+      cache: true,
       plugins: [
         rollupBabel(),
         rollupResolve({
@@ -26,3 +27,6 @@ gulp.task('default', () => {
     .pipe(sourcemaps.write())
     .pipe(gulp.dest('dist'))
 })
+
+gulp.task('watch', () => gulp.watch('src/**/*.js', ['rollup']))
+gulp.task('default', ['rollup'])

--- a/examples/gulpfile.js
+++ b/examples/gulpfile.js
@@ -12,7 +12,7 @@ gulp.task('rollup', () => {
     ])
     .pipe(sourcemaps.init())
     .pipe(rollupEach({
-      cache: true,
+      isCache: true,
       plugins: [
         rollupBabel(),
         rollupResolve({

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,8 @@ const PluginError = require('plugin-error')
 
 const PLUGIN_NAME = 'gulp-rollup-each'
 
+let cache // cache - (outside of export)
+
 module.exports = function (arg1, arg2, injectedRollup) {
   const rollup = (injectedRollup || defaultRollup).rollup
 
@@ -15,7 +17,8 @@ module.exports = function (arg1, arg2, injectedRollup) {
 
       let inputOptions = typeof arg1 === 'function' ? arg1(file) : arg1
       inputOptions = Object.assign({}, inputOptions, {
-        input: input
+        input: input,
+        cache: inputOptions.cache ? cache : false
       })
 
       // Extract output options from input options if arg2 does not exist
@@ -28,6 +31,12 @@ module.exports = function (arg1, arg2, injectedRollup) {
 
       rollup(inputOptions)
         .then(bundle => {
+
+          // cache the bundle
+          if (bundle.cache) {
+            cache = bundle.cache
+          }
+
           return bundle.generate(outputOptions)
         })
         .then(

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,55 +6,65 @@ const PluginError = require('plugin-error')
 
 const PLUGIN_NAME = 'gulp-rollup-each'
 
-let cache // cache - (outside of export)
+const cache = {} // cache - (outside of export)
 
 module.exports = function (arg1, arg2, injectedRollup) {
   const rollup = (injectedRollup || defaultRollup).rollup
 
   return new class extends Transform {
-    _transform (file, encoding, cb) {
+
+    _transform(file, encoding, cb) {
+
       const input = path.relative(file.cwd, file.path)
+      const ref = path.parse(input) // Input name
 
       let inputOptions = typeof arg1 === 'function' ? arg1(file) : arg1
       inputOptions = Object.assign({}, inputOptions, {
         input: input,
-        cache: inputOptions.cache ? cache : false
+        cache: inputOptions.isCache ? cache[ref.name] : false
       })
+
+      // Replace `isCache` option for object
+      // Prevent Rollup throwing error of unkown `isCache` key.
+      delete Object.assign(inputOptions, {
+        ['cache']: inputOptions['isCache']
+      })['isCache'];
 
       // Extract output options from input options if arg2 does not exist
       arg2 = arg2 == null ? inputOptions.output : arg2
       const outputOptions = typeof arg2 === 'function' ? arg2(file) : arg2
 
+      // SourceMap
       const createSourceMap = file.sourceMap !== undefined
-
       outputOptions.sourcemap = createSourceMap
 
       rollup(inputOptions)
-        .then(bundle => {
+      .then(bundle => {
+        // cache the bundle
+        if (bundle.cache) {
+          cache[ref.name] = bundle.cache
+        }
 
-          // cache the bundle
-          if (bundle.cache) {
-            cache = bundle.cache
+        return bundle.generate(outputOptions)
+      })
+      .then(
+        result => {
+          file.contents = Buffer.from(result.code)
+
+          if (createSourceMap) {
+            result.map.file = input
+            result.map.sources = result.map.sources.map(source => path.relative(file.cwd, source))
+            applySourceMap(file, result.map)
           }
 
-          return bundle.generate(outputOptions)
-        })
-        .then(
-          result => {
-            file.contents = Buffer.from(result.code)
-
-            if (createSourceMap) {
-              result.map.file = input
-              result.map.sources = result.map.sources.map(source => path.relative(file.cwd, source))
-              applySourceMap(file, result.map)
-            }
-
-            cb(null, file)
-          },
-          err => {
-            cb(new PluginError(PLUGIN_NAME, err))
-          }
-        )
+          cb(null, file)
+        },
+        err => {
+          cb(new PluginError(PLUGIN_NAME, err))
+        }
+      )
     }
-  }({ objectMode: true })
+  }({
+    objectMode: true
+  })
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,9 +26,7 @@ module.exports = function (arg1, arg2, injectedRollup) {
 
       // Replace `isCache` option for object
       // Prevent Rollup throwing error of unkown `isCache` key.
-      delete Object.assign(inputOptions, {
-        ['cache']: inputOptions['isCache']
-      })['isCache'];
+      delete inputOptions.isCache
 
       // Extract output options from input options if arg2 does not exist
       arg2 = arg2 == null ? inputOptions.output : arg2


### PR DESCRIPTION
Support for Rollup cache which speeds up subsequent builds. 

Plugin can set rollup cache using `cache: true` within `inputOptions`. If cache option is set to `false` or the key is `undefined` rollup will not cache the bundle.

```
rollupEach({
      // inputOptions
      cache: true, // use rollup cache
      external: [
        'jquery'
      ],
      plugins: [
        rollupBuble({
          target: {
            ie: 11
          }
        })
      ]
    }, {
      // outputOptions
      format: 'iife',
      globals: {
        jquery: 'jQuery'
      }
    })
```

https://github.com/ko-yelie/gulp-rollup-each/issues/12