### PR TITLE
Support for Rollup v1.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
 node_modules/
 dist/
 yarn.lock
-package-lock.json
 examples/yarn.lock
-examples/package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 node_modules/
 dist/
+yarn.lock
+package-lock.json
+examples/yarn.lock
+examples/package-lock.json

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ You can also pass a function that returns rollup options object as an argument. 
 
 #### `rollup`
 
-You can specify the 1st argument for replacing `rollup` object by your dependency. It is useful if you want to use a new version of rollup than gulp-rollup-each is using.
+You can specify the 3rd argument for replacing `rollup` object by your dependency. It is useful if you want to use a new version of rollup than gulp-rollup-each is using.
 
 ```js
 
@@ -130,11 +130,17 @@ function scripts () {
   return gulp.src([
     'src/**/*.js'
   ]).pipe(
-    rollupEach({ /* .. */ }, {
-      output: {
-        format: 'iife'
-      }
-    }, require('rollup'))
+    rollupEach(
+      {},
+      {
+        output: {
+          format: 'iife'
+        }
+      },
+
+      // Passing rollup object
+      require('rollup')
+    )
   ).pipe(
     gulp.dest('dist')
   )

--- a/README.md
+++ b/README.md
@@ -39,13 +39,15 @@ const sourcemaps = require('gulp-sourcemaps')
 const rollupEach = require('gulp-rollup-each')
 const rollupBuble = require('rollup-plugin-buble')
 
-gulp.task('rollup', () => {
+function scripts () {
+
   return gulp.src([
-      'src/**/*.js',
-      '!src/**/_*' // exclude modules
-    ])
-    .pipe(sourcemaps.init())
-    .pipe(rollupEach({
+    'src/**/*.js',
+    '!src/**/_*' // exclude modules
+  ]).pipe(
+    sourcemaps.init()
+  ).pipe(
+    rollupEach({
       // inputOptions
       isCache: true, // use rollup cache
       external: [
@@ -64,10 +66,13 @@ gulp.task('rollup', () => {
       globals: {
         jquery: 'jQuery'
       }
-    }))
-    .pipe(sourcemaps.write())
-    .pipe(gulp.dest('dist'))
-})
+    })
+  ).pipe(
+    sourcemaps.write()
+  ).pipe(
+    gulp.dest('dist')
+  )
+}
 ```
 
 You can also pass a function that returns rollup options object as an argument. The function will receive [vinyl](https://github.com/gulpjs/vinyl) file object.
@@ -77,21 +82,25 @@ const path = require('path')
 const gulp = require('gulp')
 const rollupEach = require('gulp-rollup-each')
 
-gulp.task('rollup', () => {
+function scripts () {
+
   return gulp.src([
-      'src/**/*.js',
-      '!src/**/_*' // exclude modules
-    ])
-    .pipe(rollupEach({
+    'src/**/*.js',
+    '!src/**/_*' // exclude modules
+  ]).pipe(
+    rollupEach({
+      external: [/* ... */],
       plugins: [/* ... */]
     }, (file) => {
       return {
         format: 'umd',
         name: path.basename(file.path, '.js')
       }
-    }))
-    .pipe(gulp.dest('dist'))
-})
+    })
+  ).pipe(
+    gulp.dest('dist')
+  )
+}
 ```
 
 ## Options
@@ -112,27 +121,25 @@ You can also pass a function that returns rollup options object as an argument. 
 
 #### `rollup`
 
-You can specify the 3rd argument for replacing `rollup` object by your dependency. It is useful if you want to use a new version of rollup than gulp-rollup-each is using.
+You can specify the 1st argument for replacing `rollup` object by your dependency. It is useful if you want to use a new version of rollup than gulp-rollup-each is using.
 
 ```js
-gulp.task('rollup', () => {
-    return gulp
-    .src(['src/**/*.js'])
-    .pipe(
-      rollupEach(
-        {},
-        {
-          output: {
-            format: 'iife'
-          }
-        },
 
-        // Passing rollup object
-        require('rollup')
-      )
-    )
-    .pipe(gulp.dest('dist'))
-})
+function scripts () {
+
+  return gulp.src([
+    'src/**/*.js'
+  ]).pipe(
+    rollupEach({ /* .. */ }, {
+      output: {
+        format: 'iife'
+      }
+    }, require('rollup'))
+  ).pipe(
+    gulp.dest('dist')
+  )
+}
+
 ```
 
 ## License

--- a/examples/gulpfile.js
+++ b/examples/gulpfile.js
@@ -5,13 +5,15 @@ const rollupResolve = require('rollup-plugin-node-resolve')
 const rollupCommon = require('rollup-plugin-commonjs')
 const sourcemaps = require('gulp-sourcemaps')
 
-gulp.task('rollup', () => {
+function scripts() {
+
   return gulp.src([
-      'src/**/*.js',
-      '!src/**/modules/*.js'
-    ])
-    .pipe(sourcemaps.init())
-    .pipe(rollupEach({
+    'src/**/*.js',
+    '!src/**/modules/*.js'
+  ]).pipe(
+    sourcemaps.init()
+  ).pipe(
+    rollupEach({
       isCache: true,
       plugins: [
         rollupBabel(),
@@ -23,10 +25,19 @@ gulp.task('rollup', () => {
       ]
     }, {
       format: 'iife'
-    }))
-    .pipe(sourcemaps.write())
-    .pipe(gulp.dest('dist'))
-})
+    })
+  ).pipe(
+    sourcemaps.write()
+  ).pipe(
+    gulp.dest('dist')
+  )
 
-gulp.task('watch', () => gulp.watch('src/**/*.js', ['rollup']))
-gulp.task('default', ['rollup'])
+}
+
+function watch () {
+  gulp.watch('src/**/*.js', scripts)
+}
+
+gulp.task('rollup', scripts)
+gulp.task('watch', watch)
+gulp.task('default', gulp.series('rollup'))

--- a/examples/package.json
+++ b/examples/package.json
@@ -2,10 +2,14 @@
   "name": "gulp-rollup-each-test",
   "version": "1.0.0",
   "devDependencies": {
-    "gulp": "^3.9.1",
+    "gulp": "^4.0.0",
     "gulp-sourcemaps": "^2.6.4",
+    "rollup": "^1.0.0",
     "rollup-plugin-babel": "^4.0.3",
     "rollup-plugin-commonjs": "^9.1.3",
-    "rollup-plugin-node-resolve": "^3.3.0"
+    "rollup-plugin-node-resolve": "^4.0.0"
+  },
+  "dependencies": {
+    "@babel/core": "^7.1.2"
   }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,6 @@ const PLUGIN_NAME = 'gulp-rollup-each'
 const cache = {} // cache - (outside of export)
 
 module.exports = function (arg1, arg2, injectedRollup) {
-
   const rollup = (injectedRollup || defaultRollup).rollup
 
   return new class extends Transform {
@@ -33,11 +32,9 @@ module.exports = function (arg1, arg2, injectedRollup) {
       arg2 = arg2 == null ? inputOptions.output : arg2
       const outputOptions = typeof arg2 === 'function' ? arg2(file) : arg2
 
-
       // SourceMap
       const createSourceMap = file.sourceMap !== undefined
       outputOptions.sourcemap = createSourceMap
-
 
       rollup(inputOptions)
       .then(bundle => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,6 +9,7 @@ const PLUGIN_NAME = 'gulp-rollup-each'
 const cache = {} // cache - (outside of export)
 
 module.exports = function (arg1, arg2, injectedRollup) {
+
   const rollup = (injectedRollup || defaultRollup).rollup
 
   return new class extends Transform {
@@ -32,9 +33,11 @@ module.exports = function (arg1, arg2, injectedRollup) {
       arg2 = arg2 == null ? inputOptions.output : arg2
       const outputOptions = typeof arg2 === 'function' ? arg2(file) : arg2
 
+
       // SourceMap
       const createSourceMap = file.sourceMap !== undefined
       outputOptions.sourcemap = createSourceMap
+
 
       rollup(inputOptions)
       .then(bundle => {
@@ -47,12 +50,13 @@ module.exports = function (arg1, arg2, injectedRollup) {
       })
       .then(
         result => {
-          file.contents = Buffer.from(result.code)
+
+          file.contents = Buffer.from(result.output[0].code)
 
           if (createSourceMap) {
-            result.map.file = input
-            result.map.sources = result.map.sources.map(source => path.relative(file.cwd, source))
-            applySourceMap(file, result.map)
+            result.output[0].map.file = input
+            result.output[0].map.sources = result.output[0].map.sources.map(source => path.relative(file.cwd, source))
+            applySourceMap(file, result.output[0].map)
           }
 
           cb(null, file)

--- a/package.json
+++ b/package.json
@@ -29,12 +29,12 @@
   "devDependencies": {
     "babel-eslint": "^10.0.1",
     "babel-register": "^6.18.0",
-    "eslint": "^5.6.1",
-    "jasmine": "^2.99.0"
+    "eslint": "^5.11.1",
+    "jasmine": "^3.3.1"
   },
   "dependencies": {
     "plugin-error": "^1.0.1",
-    "rollup": "^0.66.6",
+    "rollup": "^1.0.0",
     "vinyl-sourcemaps-apply": "^0.2.1"
   }
 }


### PR DESCRIPTION
This PR updates plugin dependencies and now applies support for Rollup v1.0.0 regarding issue #14. This PR also includes dependency updates within the examples directory which now uses Gulp v4.